### PR TITLE
upd for purescript 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.psc*
 /.purs*
 /.psa*
+.spago

--- a/README.md
+++ b/README.md
@@ -2,31 +2,27 @@
 
 Record formatting from type-level format strings, based on [Justin Woo](https://github.com/justinwoo)'s idea.
 
-This library uses the 0.12 version of the compiler.
+This library uses the 0.15.10 version of the compiler.
 
 ## Example
 
 ```purescript
-format
-  (SProxy :: SProxy "Hi {name}! Your favourite number is {number}")
-  {name : "Bill", number : 16}
+format @"Hi {name}! Your favourite number is {number}" {name : "Bill", number : 16}
 ```
 
 produces the string
 
-```
+```console
 "Hi Bill! Your favourite number is 16"
 ```
 
 A missing field results in a type-error:
 
 ```purescript
-format
-  (SProxy "Hi {name}! Your favourite number is {number}")
-  {name : "Bill"}
+format @"Hi {name}! Your favourite number is {number}" {name : "Bill"}
 ```
 
-```
+```console
   Could not match type
 
     ( number :: t2
@@ -41,3 +37,21 @@ format
 
 The only requirement is that all the types in the record have `Show`
 instances.
+
+## Nix flake
+
+1. Install Nix.
+   - Use [single-user installation](https://nixos.org/download.html), then [enable flakes](https://nixos.wiki/wiki/Flakes).
+   - Alternatively, use an [unofficial](https://github.com/DeterminateSystems/nix-installer#the-determinate-nix-installer) installer.
+
+2. Run the default `devShell`.
+
+    ```console
+    nix develop
+    ```
+
+3. Test  the project
+
+    ```console
+    spago test
+    ```

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,105 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
+-------------------------------
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
+  with halogen-vdom.dependencies = [ "extra-dependency" ] # halogen-vdom.dependencies
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
+-------------------------------
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+-------------------------------
+-}
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.9-20230619/packages.dhall
+        sha256:b785642d3425fd99933ddf3b705af06f30dc2dd87978cffa1a45798a2eb202af
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,23 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "record-format"
+, dependencies =
+  [ "assert"
+  , "effect"
+  , "prelude"
+  , "record"
+  , "typelevel-prelude"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,9 +5,8 @@ import Prelude
 import Effect (Effect)
 import Record.Format (format)
 import Test.Assert (assert)
-import Type.Prelude (SProxy(..))
 
 main :: Effect Unit
 main = do
-  let formatted = format (SProxy :: SProxy "Hi {name}! You are {number}") {name : "Bill", number : 16}
+  let formatted = format @"Hi {name}! You are {number}" {name : "Bill", number : 16}
   assert $ formatted == "Hi Bill! You are 16"


### PR DESCRIPTION
Hi! 
I learned recently that visible type applications were added to PureScript ([changelog](https://github.com/purescript/purescript/commit/1e4e0f248cb0f16b15f72892d585974f662a7f4d), [PR](https://github.com/purescript/purescript/pull/4436)) and decided to bring them into this library.

So, `@someType` now doesn't mean a proxy as in this [post](https://blog.csongor.co.uk/purescript-safe-printf/) by @kcsongor about safe printf.